### PR TITLE
kaist-audio-book -> kaistaudiobook

### DIFF
--- a/Tacotron2-Wavenet-Korean-TTS/train_tacotron2.py
+++ b/Tacotron2-Wavenet-Korean-TTS/train_tacotron2.py
@@ -240,7 +240,7 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--log_dir', default='logdir-tacotron2')
-    data_dirs = [f'./kaist-audio-book/wav/m{i}' for i in range(1, 7)] + [f'./kaist-audio-book/wav/w{i}' for i in range(1, 6)]
+    data_dirs = [f'./kaistaudiobook/wav/m{i}/' for i in range(1, 7)] + [f'./kaistaudiobook/wav/w{i}/' for i in range(1, 6)]
     parser.add_argument('--data_paths', default=','.join(data_dirs))
     #parser.add_argument('--data_paths', default='D:\\hccho\\Tacotron-Wavenet-Vocoder-hccho\\data\\small1,D:\\hccho\\Tacotron-Wavenet-Vocoder-hccho\\data\\small2')
     

--- a/Tacotron2-Wavenet-Korean-TTS/train_vocoder.py
+++ b/Tacotron2-Wavenet-Korean-TTS/train_vocoder.py
@@ -17,7 +17,7 @@ import tensorflow as tf
 from tensorflow.python.client import timeline
 from datetime import datetime
 from wavenet import WaveNetModel,mu_law_decode
-from kaist-audio-book import DataFeederWavenet
+from kaistaudiobook import DataFeederWavenet
 from hparams import hparams
 from utils import validate_directories,load,save,infolog,get_tensors_in_checkpoint_file,build_tensors_in_checkpoint_file,plot,audio
 
@@ -116,14 +116,14 @@ def create_network(hp,batch_size,num_speakers,is_training):
 def main():
     def _str_to_bool(s):
         """Convert string to bool (in argparse context)."""
-        if s.lower() not in ['true', 'false']
+        if s.lower() not in ['true', 'false']:
             raise ValueError('Argument needs to be a boolean, got {}'.format(s))
         return {'true': True, 'false': False}[s.lower()]
     
     
     parser = argparse.ArgumentParser(description='WaveNet example network')
     
-    data_dirs = ['./kaist-audio-book/wav/m{i}' for i in range(1, 7)] + ['./kaist-audio-book/wav/w{i}' for i in range(1, 6)]
+    data_dirs = [f'./kaistaudiobook/wav/m{i}' for i in range(1, 7)] + [f'./kaistaudiobook/wav/w{i}' for i in range(1, 6)]
     DATA_DIRECTORY =  ','.join(data_dirs)
     #DATA_DIRECTORY =  'D:\\hccho\\Tacotron-Wavenet-Vocoder-hccho\\data\\moon'
     parser.add_argument('--data_dir', type=str, default=DATA_DIRECTORY, help='The directory containing the VCTK corpus.')


### PR DESCRIPTION
### 내용
PR1에서 kaist-audio-book 디렉토리를 kaistaudiobook으로 변환함에 따라
경로 설정할 때 kaistaudiobook으로 변환하도록 수정

train_tacotron2.py line243
`data_dirs = [f'./kaistaudiobook/wav/m{i}/' for i in range(1, 7)] +[f'./kaistaudiobook/wav/w{i}/' for i in range(1, 6)]`


train_vocoder.py line126
`data_dirs = [f'./kaistaudiobook/wav/m{i}/' for i in range(1, 7)] +[f'./kaistaudiobook/wav/w{i}/' for i in range(1, 6)]`