### PR TITLE
batch2.py 추가 ../batch/batch.py 삭제

### DIFF
--- a/Tacotron2-Wavenet-Korean-TTS/batch2.py
+++ b/Tacotron2-Wavenet-Korean-TTS/batch2.py
@@ -1,0 +1,8 @@
+import os
+import argparse
+
+argparse.ArgumentParser()
+parser.add_argument('--cmd', required = True, help='order')
+opt = parser.parse_args()
+
+os.system(opt.cmd)


### PR DESCRIPTION
### 개요
사용자 입력 페이지 서비스 지원을 위한 batch2.py생성
사용하지않는 batch/batch.py삭제

### 내용
경로문제로 인한 batch2.py를 Tacotron2-Wavenet-Korean-TTS 디렉토리 내에 생성
batch/batch.py 삭제

따라서 Tacotron2-Wavenet-Korean-TTS 내에는 batch, batch2 두 개의 배치파일 존재
batch는 동화 텍스트를 synthesizer 수행시 실행되는 파일
batch2는 사용자 입력 텍스트를 synthesizer 수행시 실행되는 파일